### PR TITLE
Added some customization options for trigger_count

### DIFF
--- a/fgd_def/pd_300.def
+++ b/fgd_def/pd_300.def
@@ -788,9 +788,19 @@ set "message" to text string
 
 Acts as an intermediary for an action that takes multiple inputs.
 
-If nomessage is not set, t will print "1 more.. " etc when triggered and "sequence complete" when finished.
+Personalize messages:
+- message_complete: Message to show when the sequence is complete. (default: "Sequence completed!")
+- message_more: Message to show when there are more to go. (default: "There are more to go..."). This has precedence over the partials.
+- message_more_a: First part of the 'more' message.
+- message_more_b: Last part of the 'more' message.
+- message_count: Message to show when there are few to go. This has precedence over the partials.
+- message_count_a: First part of the 'count' message. (default: "Only")
+- message_count_b: Last part of the 'count' message. (default: "more to go...")
+- message_one (optional): Custom message when only one remains.
+- count: After the counter has been triggered "count" times it will fire all of it's targets and remove itself. (default: 2)
+- count_more: If more than this quantity remains, the 'more' message variant is used. Otherwise uses the 'count' message. -1 to always use 'count' variant. (default: 3)
 
-After the counter has been triggered "count" times (default 2), it will fire all of it's targets and remove itself.
+Note: The 'more' and 'few' version depends on the 'count_more' value.
 */
 /*QUAKED info_teleport_changedest (0 0.5 0) (-8 -8 -8) (8 8 8) X X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
 Allows a mapper to change the target of a teleport_trigger. Useful in maps where

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -2415,12 +2415,31 @@ Make sure and add a weapon_shotgun to your map!"
 	height(integer) : "Jump Height" : 200
 	spawnflags(flags) = [ 8: "Start Off (toggles)" : 0 ] //dumptruck_ds
 ]
-@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter"
+@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter
+
+message_complete: Message to show when the sequence is complete.
+message_more: Message to show when there are more to go. This has precedence over the partials.
+message_more_a: First part of the 'more' message.
+message_more_b: Last part of the 'more' message.
+message_count: Message to show when there are few to go. This has precedence over the partials.
+message_count_a: First part of the 'count' message.
+message_count_b: Last part of the 'count' message.
+message_one (optional): Custom message when only one remains.
+count_more: If more than this quantity remains, the 'more' message is used. Otherwise uses the 'count' message. -1 to always use 'count' variant.
+
+Notes: The 'more' and 'few' version depends on the 'count_more' value."
 [
 	spawnflags(flags) = [ 1: "No Message" : 0 ]
 	count(integer) : "Count before trigger" : 2
-	delay (integer) : "Delay"
-	message(string) : "Message"
+	message_complete(string) : "Message on sequence completed" : "Sequence completed!"
+	message_more(string) : "Message to show when there are more to go." : "There are more to go..."
+	message_more_a(string) : "First part of the 'more' message."
+	message_more_b(string) : "Last part of the 'more' message."
+	message_count(string) : "Message to specify the remaining count. Use 'pre' and 'post' variants instead if you want to show the remaining count."
+	message_count_a(string) : "First part of the 'count' message." : "Only"
+	message_count_b(string) : "Last part of the 'count' message." : "more to go..."
+	message_one(string) : "Custom message when there's only one more to go (optional)"
+	count_more(integer) : "If more than this quantity remains, the 'more' message variant will be used. Use -1 to always show the count variant." : 3
 ]
 @SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
 [

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -2171,12 +2171,31 @@ spawnflags(Flags) =
 	height(integer) : "Jump Height" : 200
 	spawnflags(flags) = [ 8: "Start Off (toggles)" : 0 ] //dumptruck_ds
 ]
-@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter"
+@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter
+
+message_complete: Message to show when the sequence is complete.
+message_more: Message to show when there are more to go. This has precedence over the partials.
+message_more_a: First part of the 'more' message.
+message_more_b: Last part of the 'more' message.
+message_count: Message to show when there are few to go. This has precedence over the partials.
+message_count_a: First part of the 'count' message.
+message_count_b: Last part of the 'count' message.
+message_one (optional): Custom message when only one remains.
+count_more: If more than this quantity remains, the 'more' message variant is used. Otherwise uses the 'count' message. -1 to always use 'count' variant.
+
+Notes: The 'more' and 'few' version depends on the 'count_more' value."
 [
 	spawnflags(flags) = [ 1: "No Message" : 0 ]
 	count(integer) : "Count before trigger" : 2
-	delay (integer) : "Delay"
-	message(string) : "Message"
+	message_complete(string) : "Message on sequence completed" : "Sequence completed!"
+	message_more(string) : "Message to show when there are more to go." : "There are more to go..."
+	message_more_a(string) : "First part of the 'more' message."
+	message_more_b(string) : "Last part of the 'more' message."
+	message_count(string) : "Message to specify the remaining count. Use 'pre' and 'post' variants instead if you want to show the remaining count."
+	message_count_a(string) : "First part of the 'count' message." : "Only"
+	message_count_b(string) : "Last part of the 'count' message." : "more to go..."
+	message_one(string) : "Custom message when there's only one more to go (optional)"
+	count_more(integer) : "If more than this quantity remains, the 'more' message will be used. Use -1 to always show the count variant." : 3
 ]
 @SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
 [

--- a/qc/defs.qc
+++ b/qc/defs.qc
@@ -566,6 +566,16 @@ float	AS_TURRET		= 5;
 //
 .float		count;			// for counting triggers
 
+// For trigger_count
+.string		message_complete;	// Use for "Sequence completed!"
+.string		message_more;		// Use for "There are more to go..."
+.string		message_more_a;		// Use for partial message.
+.string		message_more_b;		// Use for partial message.
+.string		message_count;		// Use for "Only a few more to go..."
+.string		message_count_a;	// Use for the partial "Only" part of the string.
+.string		message_count_b;	// Use for the "more to go..." part of the string.
+.string		message_one;		// Use for "Only 1 more to go..."
+.float		count_more;			// If more than this value remains, 'message_more' is used. -1 to never.
 
 //
 // plats / doors / buttons

--- a/qc/triggers.qc
+++ b/qc/triggers.qc
@@ -261,47 +261,69 @@ void() trigger_secret =
 	trigger_multiple ();
 };
 
-//=============================================================================
+/*
+==============================================================================
 
+Added custom message options for trigger_counter.
+-- rijuma
+
+==============================================================================
+*/
 
 void() counter_use =
 {
 	if (self.estate != STATE_ACTIVE) return;
 
+	// Is self.count is 0 or less, this was already done. Ignore.
+	if (self.count <= 0) return;
+	
 	self.count = self.count - 1;
-	if (self.count < 0)
-		return;
+	
+	// Check conditions for showing message
+	local float showMessage = (activator.classname == "player" && (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0);
+	
+	// If the count reaches 0, we trigger the event.
+	if (self.count == 0) {
+		if (showMessage)
+			centerprint (activator, self.message_complete);
 
-	if (self.count != 0)
-	{
-		if (activator.classname == "player"
-		&& (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
-		{
-			if (self.count >= 4)
-				centerprint (activator, "There are more to go...");
-			else if (self.count == 3)
-				centerprint (activator, "Only 3 more to go...");
-			else if (self.count == 2)
-				centerprint (activator, "Only 2 more to go...");
-			else
-				centerprint (activator, "Only 1 more to go...");
-		}
-		return;
+		self.enemy = activator;
+		return multi_trigger ();
 	}
 
-	if (activator.classname == "player"
-	&& (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
-		centerprint(activator, "Sequence completed!");
-	self.enemy = activator;
-	multi_trigger ();
+	// Otherwise, more activations remain, so let's handle that.
+
+	// If there's no message, then nothing to do here.
+	if (!showMessage) return;
+
+	// First we check if we want to tell exactly how many attempts we have left or not.
+	// If the remaining count is greater than count_more, we do use message_more.
+	// Use count_more = -1 to never use message_more (Always use message_count).
+	if (self.count_more != -1 && self.count > self.count_more) {
+		// If message_more is set, we use it (no count shown).
+		if (self.message_more)
+			return centerprint (activator, self.message_more);
+
+		// Otherwise we concatenate the partial strings with the current count.
+		return centerprint_builtin5 (activator, self.message_more_a, " ", ftos(self.count), " ", self.message_more_b);
+	}
+
+	// If only one remains, we check if we have a custom message for this case, otherwise we use the template.
+	if (self.count == 1 && self.message_one)
+		return centerprint (activator, self.message_one);
+	
+	// Lastly, we show the template (how I miss string handling functions *sigh*...).
+
+	// If message_count is set, we use it (no count shown).
+	if (self.message_count)
+		return centerprint (activator, self.message_count);
+
+	// Otherwise we concatenate the partial strings with the current count.
+	return centerprint_builtin5 (activator, self.message_count_a, " ", ftos(self.count), " ", self.message_count_b);
 };
 
 /*QUAKED trigger_counter (.5 .5 .5) ? nomessage X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
-
 Acts as an intermediary for an action that takes multiple inputs.
-
-If nomessage is not set, t will print "1 more.. " etc when triggered and "sequence complete" when finished.
-
 After the counter has been triggered "count" times (default 2), it will fire all of it's targets and remove itself.
 */
 void() trigger_counter =
@@ -309,10 +331,47 @@ void() trigger_counter =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	self.wait = -1;
+	// Default values
 	if (!self.count)
 		self.count = 2;
 
+	if (self.message_complete) {
+		// Backwards compatibility only. The 'message' parameter is discouraged.
+		if (self.message) 
+			self.message_complete = self.message;
+		else if (!self.message_complete)
+			self.message_complete = "Sequence completed!";
+	}
+
+	if (self.message_more) {
+		// We prioritize self.message_more over the partials.
+		self.message_more_a = "";
+		self.message_more_b = "";
+	} if (!self.message_more_a && !self.message_more_b) {
+		// Defaults are only set if partials are not set.
+		self.message_more = "There are more to go...";
+	}
+
+	if (self.message_count) {
+		// We prioritize self.message_count over the partials.
+		self.message_count_a = "";
+		self.message_count_b = "";
+	} if (!self.message_count_a && !self.message_count_b) {
+		// Defaults are only set if both are empty.
+		// This allows the use of only one part or both.
+		self.message_count_a = "Only";
+		self.message_count_b = "more to go...";
+	}
+
+	if (!self.count_more)
+		self.count_more = 3;
+
+	// Clear deprecated message parameter.
+	self.message = "";
+
+	// This disables wait for some reason, I've removed it from the .fgd/.def file. Maybe a TODO check for this functionality?
+	self.wait = -1; 
+	
 	self.use = counter_use;
 };
 


### PR DESCRIPTION
## New stuff added

### Entity: `trigger_counter`

#### Params added
- `message_complete`: Message to show when the sequence is complete. _(default: "Sequence completed!")_
- `message_more`: Message to show when there are more to go. This has precedence over the partials. _(default: "There are more to go...")_
- `message_more_a`: First part of the **more** message variant.
- `message_more_b`: Last part of the **more** message variant.
- `message_count`: Message to show when there are few to go. This has precedence over the partials.
- `message_count_a`: First part of the **count** message variant. _(default: "Only")_
- `message_count_b`: Last part of the **count** message variant. _(default: "more to go...")_
- `message_one` _(optional)_: Custom message when only one remains.
- `count_more`: If more than this quantity remains, the **more** message is used. Otherwise uses the **count** message. **-1** to always use **count** variant. _(default: 3)_

#### Params removed (from fgd y def) files
- `wait`: If you check progs_dump's current code, it basically sets the wait to **-1** disabling its behavior. No use being shown in the editor.
- `message`: Since it now has several message parameters, I use it as an alias for `message_complete` for backward compatibility, but I removed it from the editor to discourage its use since it's clearer this way.

## Extra notes

I know splitting the values for the pre and post message it's cumbersome, but there are no string handling functions available without adding dependencies, so this is the best I could do.

## Test map 
[trigger_count_test-v0.2.zip](https://github.com/progs-dump-dev/progs_dump/files/10874599/trigger_count_test-v0.2.zip)

## Screenshots
![image](https://user-images.githubusercontent.com/12736783/222520459-2a1b4e98-5378-4bf4-8baa-dfaeee24e3cb.png)

